### PR TITLE
Bug fixes in powershell and fixed a typo in Readme.rst

### DIFF
--- a/Libraries/Python/CommonEnvironment/v1.0/CommonEnvironment/Shell/WindowsPowerShell.py
+++ b/Libraries/Python/CommonEnvironment/v1.0/CommonEnvironment/Shell/WindowsPowerShell.py
@@ -6,12 +6,7 @@
 # |      2018-06-07 16:38:31
 # |  
 # ----------------------------------------------------------------------
-# |  
-# |  Copyright Michael Sharp 2018.
-# |  Distributed under the Boost Software License, Version 1.0.
-# |  (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-# |  
-# ----------------------------------------------------------------------
+
 """Contains the WindowsPowerShell object."""
 
 import os
@@ -59,12 +54,12 @@ class WindowsPowerShell(WindowsShell):
             
             for line in command.Value.split('\n'):
                 if not line.strip():
-                    output.append("Write-Output ''")
+                    output.append("echo.")
                 else:
                     for old_char, new_char in replacement_chars:
                         line = line.replace(old_char, new_char)
                         
-                    output.append("Write-Output '{}'".format(line))
+                    output.append("echo {}".format(line))
                     
             return '\n'.join(output)
 

--- a/Readme.rst
+++ b/Readme.rst
@@ -226,7 +226,7 @@ From an activated_ environment_, run:
   Windows (PowerShell)       ``python $env:DEVELOPMENT_ENVIRONMENT_FUNDAMENTAL\RepositoryBootstrap\CreateRepository.py <Destination Repository Dir> <Repository Name>``
   =========================  =======================================
   
-  The script will prompt you for information and then generated the necessary files in ``<Destination Repository Dir>``.
+  The script will prompt you for information and then generate the necessary files in ``<Destination Repository Dir>``.
   
 Support
 =======

--- a/Readme.rst
+++ b/Readme.rst
@@ -223,6 +223,7 @@ From an activated_ environment_, run:
   =========================  =======================================
   Linux                      ``python $DEVELOPMENT_ENVIRONMENT_FUNDAMENTAL/RepositoryBootstrap/CreateRepository.py <Destination Repository Dir> <Repository Name>``
   Windows                    ``python %DEVELOPMENT_ENVIRONMENT_FUNDAMENTAL%\RepositoryBootstrap\CreateRepository.py <Destination Repository Dir> <Repository Name>``
+  Windows (PowerShell)       ``python $env:DEVELOPMENT_ENVIRONMENT_FUNDAMENTAL\RepositoryBootstrap\CreateRepository.py <Destination Repository Dir> <Repository Name>``
   =========================  =======================================
   
   The script will prompt you for information and then generated the necessary files in ``<Destination Repository Dir>``.

--- a/RepositoryBootstrap/Impl/Activate.ps1
+++ b/RepositoryBootstrap/Impl/Activate.ps1
@@ -6,12 +6,6 @@
 # |      2018-06-07 16:38:31
 # |  
 # ----------------------------------------------------------------------
-# |  
-# |  Copyright Michael Sharp 2018.
-# |  Distributed under the Boost Software License, Version 1.0.
-# |  (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-# |  
-# ----------------------------------------------------------------------
 
 function ExitScript {
     if($env:_ACTIVATE_ENVIRONMENT_TEMP_SCRIPT_NAME){
@@ -20,17 +14,17 @@ function ExitScript {
     Remove-Item "NULL" -ErrorAction SilentlyContinue
 
     $env:DEVELOPMENT_ENVIRONMENT_FUNDAMENTAL=$env:_ACTIVATE_ENVIRONMENT_PREVIOUS_FUNDAMENTAL
-    $env:_ACTIVATE_ENVIRONMENT_SCRIPT_EXECUTION_ERROR_LEVEL=''
-    $env:_ACTIVATE_ENVIRONMENT_SCRIPT_GENERATION_ERROR_LEVEL=''
-    $env:_ACTIVATE_ENVIRONMENT_CLA=''
-    $env:_ACTIVATE_ENVIRONMENT_WORKING_DIR=''
-    $env:_ACTIVATE_ENVIRONMENT_PYTHON_BINARY=''
-    $env:_ACTIVATE_ENVIRONMENT_IS_CONFIGURABLE_REPOSITORY=''
-    $env:_ACTIVATE_ENVIRONMENT_IS_MIXIN_REPOSITORY=''
-    $env:_ACTIVATE_ENVIRONMENT_PREVIOUS_FUNDAMENTAL=''
-    $env:_ACTIVATE_ENVIRONMENT_TEMP_SCRIPT_NAME=''
-    $env:PYTHONPATH=''
-    $env:PYTHONUNBUFFERED=''
+    Remove-Item "Env:\_ACTIVATE_ENVIRONMENT_SCRIPT_EXECUTION_ERROR_LEVEL" -ErrorAction SilentlyContinue
+    Remove-Item "Env:\_ACTIVATE_ENVIRONMENT_SCRIPT_GENERATION_ERROR_LEVEL" -ErrorAction SilentlyContinue
+    Remove-Item "Env:\_ACTIVATE_ENVIRONMENT_CLA" -ErrorAction SilentlyContinue
+    Remove-Item "Env:\_ACTIVATE_ENVIRONMENT_WORKING_DIR" -ErrorAction SilentlyContinue
+    Remove-Item "Env:\_ACTIVATE_ENVIRONMENT_PYTHON_BINARY" -ErrorAction SilentlyContinue
+    Remove-Item "Env:\_ACTIVATE_ENVIRONMENT_IS_CONFIGURABLE_REPOSITORY" -ErrorAction SilentlyContinue
+    Remove-Item "Env:\_ACTIVATE_ENVIRONMENT_IS_MIXIN_REPOSITORY" -ErrorAction SilentlyContinue
+    Remove-Item "Env:\_ACTIVATE_ENVIRONMENT_PREVIOUS_FUNDAMENTAL" -ErrorAction SilentlyContinue
+    Remove-Item "Env:\_ACTIVATE_ENVIRONMENT_TEMP_SCRIPT_NAME" -ErrorAction SilentlyContinue
+    Remove-Item "Env:\PYTHONPATH" -ErrorAction SilentlyContinue
+    Remove-Item "Env:\PYTHONUNBUFFERED" -ErrorAction SilentlyContinue
     
     Pop-Location 
     
@@ -45,6 +39,10 @@ function ErrorExit {
 function CreateTempScriptName {
     $env:_filename = "$PSScriptRoot\ActivateEnvironment-$(Get-Random -Maximum 99999)-$(Get-Date -Format mm-ss).ps1"
     $env:_ACTIVATE_ENVIRONMENT_TEMP_SCRIPT_NAME = $env:_filename
+}
+
+function echo. {
+    echo "`n"
 }
 
 Push-Location $PSScriptRoot
@@ -105,7 +103,7 @@ $env:_ACTIVATE_ENVIRONMENT_PREVIOUS_FUNDAMENTAL=$env:DEVELOPMENT_ENVIRONMENT_FUN
 
 # ----------------------------------------------------------------------
 # |  Only allow one activated environment at a time (unless we are activating a mixin repo)
-if ($env:_ACTIVATE_ENVIRONMENT_IS_MIXIN_REPOSITORY -ne "1" -and $env:DEVELOPMENT_ENVIRONMENT_REPOSITORY -ne "" -and $env:DEVELOPMENT_ENVIRONMENT_REPOSITORY -ne $PSScriptRoot -and $null -ne $env:DEVELOPMENT_ENVIRONMENT_REPOSITORY) {
+if ($env:_ACTIVATE_ENVIRONMENT_IS_MIXIN_REPOSITORY -ne "1" -and (![string]::IsNullOrEmpty($env:DEVELOPMENT_ENVIRONMENT_REPOSITORY)) -and $env:DEVELOPMENT_ENVIRONMENT_REPOSITORY -ne $PSScriptRoot -and (![string]::IsNullOrEmpty($env:DEVELOPMENT_ENVIRONMENT_REPOSITORY))) {
     Write-Host  ""
     Write-Error "Only one repository can be activated within an environment at a time, and it appears as if one is already active. Please open a new console and run this script again."
     Write-Host  ""

--- a/RepositoryBootstrap/Templates/Setup.ps1
+++ b/RepositoryBootstrap/Templates/Setup.ps1
@@ -6,12 +6,6 @@
 # |      2018-06-07 11:21:37
 # |  
 # ----------------------------------------------------------------------
-# |  
-# |  Copyright Michael Sharp 2018.
-# |  Distributed under the Boost Software License, Version 1.0.
-# |  (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-# |  
-# ----------------------------------------------------------------------
 
 # ----------------------------------------------------------------------
 # |  
@@ -27,7 +21,7 @@ function ExitScript {
     exit
 }
 
-if ($env:DEVELOPMENT_ENVIRONMENT_FUNDAMENTAL -eq "") {
+if ([string]::IsNullOrEmpty($env:DEVELOPMENT_ENVIRONMENT_FUNDAMENTAL)) {
     Write-Host  ""
     Write-Error "ERROR: Please run Activate.ps1 within a repository before running this script. It may be necessary to Setup and Activate the Common_Environment repository before setting up this one."
     Write-Host  ""

--- a/Setup.ps1
+++ b/Setup.ps1
@@ -6,12 +6,7 @@
 # |      2018-06-07 11:21:37
 # |  
 # ----------------------------------------------------------------------
-# |  
-# |  Copyright Michael Sharp 2018.
-# |  Distributed under the Boost Software License, Version 1.0.
-# |  (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-# |  
-# ----------------------------------------------------------------------
+
 
 # ----------------------------------------------------------------------
 # |  
@@ -27,12 +22,16 @@ function ExitScript {
     exit
 }
 
+function echo. {
+    echo "`n"
+}
+
 # Begin bootstrap customization
 $env:DEVELOPMENT_ENVIRONMENT_FUNDAMENTAL=$PSScriptRoot
 
-Invoke-Expression "$env:DEVELOPMENT_ENVIRONMENT_FUNDAMENTAL\RepositoryBootstrap\Impl\Fundamental\Setup.cmd $args" 
+$success = Invoke-Expression "$env:DEVELOPMENT_ENVIRONMENT_FUNDAMENTAL\RepositoryBootstrap\Impl\Fundamental\Setup.cmd $args;`$?"
 
-if( -not $? ){
+if( -not $success ){
     $msg = $Error[0].Exception.Message
     Write-Host  ""
     Write-Host  ""
@@ -45,7 +44,7 @@ if( -not $? ){
 }
 # End bootstrap customization
 
-if ($env:DEVELOPMENT_ENVIRONMENT_FUNDAMENTAL -eq "") {
+if ([string]::IsNullOrEmpty($env:DEVELOPMENT_ENVIRONMENT_FUNDAMENTAL)) {
     Write-Host  ""
     Write-Error "ERROR: Please run Activate.ps1 within a repository before running this script. It may be necessary to Setup and Activate the Common_Environment repository before setting up this one."
     Write-Host  ""
@@ -56,6 +55,6 @@ if ($env:DEVELOPMENT_ENVIRONMENT_FUNDAMENTAL -eq "") {
 Invoke-Expression "$env:DEVELOPMENT_ENVIRONMENT_FUNDAMENTAL\RepositoryBootstrap\Impl\Setup.cmd $env:DEVELOPMENT_ENVIRONMENT_FUNDAMENTAL $args"
 
 # Bootstrap customization
-$env:DEVELOPMENT_ENVIRONMENT_FUNDAMENTAL = ""
+Remove-Item "Env:\DEVELOPMENT_ENVIRONMENT_FUNDAMENTAL"
 
 ExitScript


### PR DESCRIPTION
I removed all copyright info as we discussed.

Changed `Write-Output` back to `echo` as `Write-Output` caused issues with one script (still not sure why, it shoudln't have)

Changed generated to generate at the bottom of the `Readme.rst`

Changed how I clear the environment variables to the correct form for powershell.

Made a function called `echo.` to simulate the same output as when called from a `.cmd` file. 

Changed how I was checking for null/empty powershell environment variables to the correct way.